### PR TITLE
login_logout_features

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  include SessionsHelper
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,21 @@
+class SessionsController < ApplicationController
+  def new; end
+
+  def create
+    user = User.find_by email: params.dig(:session, :email)&.downcase
+
+    if user&.authenticate params[:session][:password]
+      reset_session
+      log_in user
+      redirect_to user, status: :see_other
+    else
+      flash.now[:danger] = "Invalid email or password"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    log_out if logged_in?
+    redirect_to root_url, status: :see_other
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new user_params
     if @user.save
+      reset_session
+      log_in @user
       flash[:success] = "Sign up success"
       redirect_to @user, status: :see_other
     else

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,18 @@
+module SessionsHelper
+  def log_in user
+    session[:user_id] = user.id
+  end
+
+  def current_user
+    @current_user ||= User.find_by id: session[:user_id]
+  end
+
+  def logged_in?
+    current_user.present?
+  end
+
+  def log_out
+    reset_session
+    @current_user = nil
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,8 +4,13 @@
     <nav>
       <ul class="nav navbar-nav navbar-right">
         <li><%= link_to "Home", root_path %></li>
-        <li><%= link_to "Sign up", signup_path %></li>
-        <li><%= link_to "Log in", "#" %></li>
+        <% if logged_in? %>
+          <li><%= link_to "Profile", user_path(@current_user) %></li>
+          <li><%= link_to "Log out", logout_path, data: {turbo_method: :delete} %></li>
+        <% else %>
+          <li><%= link_to "Sign up", signup_path %></li>
+          <li><%= link_to "Log in", login_path %></li>
+        <% end %>
       </ul>
     </nav>
   </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,21 @@
+<h1>Login</h1>
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with model: @session, url: login_path do |form| %>
+      <div>
+        <%= form.label :email %><br>
+        <%= form.text_field :email %>
+      </div>
+
+      <div>
+        <%= form.label :password %><br>
+        <%= form.password_field :password %>
+      </div>
+
+      <div>
+        <%= form.submit %>
+      </div>
+    <% end %>
+    <p> If you are new user, please <%= link_to "sign up", signup_path %> now!</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,7 @@ Rails.application.routes.draw do
   get "/signup", to: "users#new"
   post "/signup", to: "users#create"
   resources :users, only: %i[show]
+  get "/login", to: "sessions#new"
+  post "/login", to: "sessions#create"
+  delete "/logout", to: "sessions#destroy"
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+require "shared_examples"
+include SessionsHelper
+RSpec.describe SessionsController, type: :controller do
+  describe "GET new" do
+    before do
+      get :new
+    end
+
+    it "render signup page" do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe "POST create" do
+    let(:user) {create(:user)}
+
+    context "success login" do
+      before do
+        post :create, params: {session: {email: user.email, password: user.password}}
+      end
+
+      it "should update session with user_id" do
+        expect(session[:user_id]).to eq(user.id)
+      end
+
+      it_behaves_like "redirect to user page"
+    end
+
+    context "failure when wrong email or password" do
+      before do
+        post :create, params: {session: {email: user.email, password: "wrong_password"}}
+      end
+
+      it "show flash invalid email or password" do
+        expect(flash[:danger]).to eq("Invalid email or password")
+      end
+
+      it "render login page again" do
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe "DELETE destroy" do
+    let(:user) {create(:user)}
+
+    context "logout with logged in" do
+      before do
+        log_in user
+        delete :destroy
+      end
+
+      it "clear session" do
+        expect(session[:user_id]).to be_nil
+      end
+
+      it_behaves_like "redirect to home page"
+    end
+
+    context "logout without logged in" do
+      before do
+        delete :destroy
+      end
+
+      it_behaves_like "redirect to home page"
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe UsersController, type: :controller do
   describe "POST create" do
     context "success create" do
       let(:valid_user_params) {attributes_for :user}
+
       before do
         post :create, params: {user: valid_user_params}
       end
@@ -27,13 +28,14 @@ RSpec.describe UsersController, type: :controller do
         expect(User.where(id: assigns(:user).id)).to exist
       end
 
-      it "show flash Sign up success" do
+      it "show flash sign up success" do
         expect(flash[:success]).to eq("Sign up success")
       end
     end
 
-    context "fail create" do
+    context "failure create" do
       let(:invalid_user_params) {attributes_for(:user, name: "")}
+
       before do
         post :create, params: {user: invalid_user_params}
       end
@@ -50,6 +52,7 @@ RSpec.describe UsersController, type: :controller do
 
   describe "GET show" do
     let(:user) {create(:user)}
+
     context "success show" do
       before do
         get :show, params: {id: user.id}

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -9,3 +9,9 @@ RSpec.shared_examples "show flash user not found" do
     expect(flash[:danger]).to eq("User not found")
   end
 end
+
+RSpec.shared_examples "redirect to user page" do
+  it "redirect to user page" do
+    expect(response).to redirect_to user
+  end
+end


### PR DESCRIPTION
## WHAT (optional)
- Add login logout features


## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)

![image](https://github.com/ngocnt-3479/blog/assets/173456743/c9a26096-abca-4c79-8fd5-69bbc87f3c23)
![image](https://github.com/ngocnt-3479/blog/assets/173456743/f1fcdcc0-1aea-4ffa-9387-48edf4bb9d81)
![image](https://github.com/ngocnt-3479/blog/assets/173456743/7bd2e915-422f-4edc-bb08-e0bab0f826ef)



